### PR TITLE
Add max-backlog and optional RPC_TYPE to support fast-rpc snapshots

### DIFF
--- a/down_rclone.sh
+++ b/down_rclone.sh
@@ -55,9 +55,9 @@ main() {
     --buffer-size 128M \
     --http-url $HTTP_URL \
     --files-from=$FILES_PATH \
-    --retries 10 \
+    --retries 100 \
     --retries-sleep 1s \
-    --low-level-retries 10 \
+    --low-level-retries 100 \
     --progress \
     --stats-one-line \
     :http:$PREFIX/$BLOCK/ $DATA_PATH

--- a/down_rclone.sh
+++ b/down_rclone.sh
@@ -11,6 +11,7 @@ set -e
 # - Set $TPSLIMIT to the maximum number of HTTP new actions per second. (default: 4096)
 # - Set $BWLIMIT to the maximum bandwidth to use for download in case you want to limit it. (default: 10G)
 # - Set $DATA_PATH to the path where you want to download the snapshot (default: ~/.near/data)
+# - Set $RPC_TYPE to either `rpc` or `fast-rpc` (default: rpc). `fast-rpc` is the 3 epochs and trimmed headers. `rpc` is 5 epochs and all headers.
 # - Set $BLOCK to the block height of the snapshot you want to download. If not set, it will download the latest snapshot.
 
 if ! type rclone >/dev/null 2>&1
@@ -24,9 +25,10 @@ HTTP_URL="https://snapshot.neardata.xyz"
 : "${THREADS:=128}"
 : "${TPSLIMIT:=4096}"
 : "${BWLIMIT:=10G}"
+: "${RPC_TYPE:=rpc}"
 : "${DATA_PATH:=~/.near/data}"
 
-PREFIX="$CHAIN_ID/rpc"
+PREFIX="$CHAIN_ID/$RPC_TYPE"
 
 LATEST=$(curl -s "$HTTP_URL/$PREFIX/latest.txt")
 echo "Latest snapshot block: $LATEST"
@@ -47,6 +49,7 @@ main() {
     --tpslimit $TPSLIMIT \
     --bwlimit $BWLIMIT \
     --no-traverse \
+    --max-backlog 1000000 \
     --transfers $THREADS \
     --checkers $THREADS \
     --buffer-size 128M \

--- a/down_rclone_archival.sh
+++ b/down_rclone_archival.sh
@@ -55,9 +55,9 @@ main() {
     --buffer-size 128M \
     --http-url $HTTP_URL \
     --files-from=$FILES_PATH \
-    --retries 10 \
+    --retries 100 \
     --retries-sleep 1s \
-    --low-level-retries 10 \
+    --low-level-retries 100 \
     --progress \
     --stats-one-line \
     :http:$PREFIX/$BLOCK/$DATA_TYPE/ $DATA_PATH

--- a/down_rclone_archival.sh
+++ b/down_rclone_archival.sh
@@ -51,6 +51,7 @@ main() {
     --bwlimit $BWLIMIT \
     --transfers $THREADS \
     --checkers 128 \
+    --max-backlog 1000000 \
     --buffer-size 128M \
     --http-url $HTTP_URL \
     --files-from=$FILES_PATH \


### PR DESCRIPTION
- Add `--max-backlog 1000000`. Should display better size estimate (default was 10K).
- Add flag `RPC_TYPE` to be able to select `fast-rpc` for smallest RPC snapshots with 3 epochs. About 580G.
- Increase `--retries` and `--low-level-retries` to `100` from `10`. Archival snapshots may actually trigger quite a bit of retries unfortunately.