### PR TITLE
Add multi-thread-streams 1 to fix large file issue

### DIFF
--- a/down_rclone.sh
+++ b/down_rclone.sh
@@ -46,18 +46,19 @@ main() {
   echo "Downloading $EXPECTED_NUM_FILES files with $THREADS threads"
 
   rclone copy \
+    --no-traverse \
+    --multi-thread-streams 1 \
     --tpslimit $TPSLIMIT \
     --bwlimit $BWLIMIT \
-    --no-traverse \
     --max-backlog 1000000 \
     --transfers $THREADS \
     --checkers $THREADS \
     --buffer-size 128M \
     --http-url $HTTP_URL \
     --files-from=$FILES_PATH \
-    --retries 100 \
+    --retries 10 \
     --retries-sleep 1s \
-    --low-level-retries 100 \
+    --low-level-retries 10 \
     --progress \
     --stats-one-line \
     :http:$PREFIX/$BLOCK/ $DATA_PATH

--- a/down_rclone_archival.sh
+++ b/down_rclone_archival.sh
@@ -47,17 +47,18 @@ main() {
 
   rclone copy \
     --no-traverse \
+    --multi-thread-streams 1 \
     --tpslimit $TPSLIMIT \
     --bwlimit $BWLIMIT \
+    --max-backlog 1000000 \
     --transfers $THREADS \
     --checkers 128 \
-    --max-backlog 1000000 \
     --buffer-size 128M \
     --http-url $HTTP_URL \
     --files-from=$FILES_PATH \
-    --retries 100 \
+    --retries 20 \
     --retries-sleep 1s \
-    --low-level-retries 100 \
+    --low-level-retries 10 \
     --progress \
     --stats-one-line \
     :http:$PREFIX/$BLOCK/$DATA_TYPE/ $DATA_PATH


### PR DESCRIPTION
- Add `--multi-thread-streams 1` to solve large file issues. It shouldn't affect general download speeds, since most files are usually within 1 chunk (64Mb)
- Revert retries to 10, and archival to 20. It's unnecessary to have more than 10. Better to restart the script.

Fixes #2 

