### PR TITLE
Retries and fast start

### DIFF
--- a/down_rclone.sh
+++ b/down_rclone.sh
@@ -13,6 +13,9 @@ set -e
 # - Set $DATA_PATH to the path where you want to download the snapshot (default: ~/.near/data)
 # - Set $RPC_TYPE to either `rpc` or `fast-rpc` (default: rpc). `fast-rpc` is the 3 epochs and trimmed headers. `rpc` is 5 epochs and all headers.
 # - Set $BLOCK to the block height of the snapshot you want to download. If not set, it will download the latest snapshot.
+# - Set $RETRIES to the number of retries for each file. (default: 20)
+# - Set $CHECKERS to the number of checkers to use. (default: $THREADS)
+# - Set $LOW_LEVEL_RETRIES to the number of low level retries. (default: 10)
 
 if ! type rclone >/dev/null 2>&1
 then
@@ -43,9 +46,7 @@ main() {
   mkdir -p "$DATA_PATH"
   echo "Snapshot block: $BLOCK"
 
-  if [ -z "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ]; then
-      HTTP_NO_HEAD_FLAG="--http-no-head"
-  fi
+  [ -d "$DATA_PATH" ] && [ -n "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ] && HTTP_NO_HEAD_FLAG="--http-no-head"
 
   FILES_PATH="/tmp/files.txt"
   curl -s "$HTTP_URL/$PREFIX/$BLOCK/files.txt" -o $FILES_PATH

--- a/down_rclone.sh
+++ b/down_rclone.sh
@@ -56,6 +56,7 @@ main() {
 
   rclone copy \
     --no-traverse \
+    $HTTP_NO_HEAD_FLAG \
     --multi-thread-streams 1 \
     --tpslimit $TPSLIMIT \
     --bwlimit $BWLIMIT \

--- a/down_rclone.sh
+++ b/down_rclone.sh
@@ -35,7 +35,7 @@ HTTP_URL="https://snapshot.neardata.xyz"
 : "${LOW_LEVEL_RETRIES:=10}"
 
 PREFIX="$CHAIN_ID/$RPC_TYPE"
-HTTP_NO_HEAD_FLAG=""
+HTTP_NO_HEAD_FLAG="--http-no-head"
 
 LATEST=$(curl -s "$HTTP_URL/$PREFIX/latest.txt")
 echo "Latest snapshot block: $LATEST"
@@ -46,7 +46,7 @@ main() {
   mkdir -p "$DATA_PATH"
   echo "Snapshot block: $BLOCK"
 
-  [ -d "$DATA_PATH" ] && [ -n "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ] && HTTP_NO_HEAD_FLAG="--http-no-head"
+  [ -d "$DATA_PATH" ] && [ -n "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ] && HTTP_NO_HEAD_FLAG=""
 
   FILES_PATH="/tmp/files.txt"
   curl -s "$HTTP_URL/$PREFIX/$BLOCK/files.txt" -o $FILES_PATH

--- a/down_rclone_archival.sh
+++ b/down_rclone_archival.sh
@@ -35,7 +35,7 @@ HTTP_URL="https://snapshot.neardata.xyz"
 : "${LOW_LEVEL_RETRIES:=10}"
 
 PREFIX="$CHAIN_ID/archival"
-HTTP_NO_HEAD_FLAG=""
+HTTP_NO_HEAD_FLAG="--http-no-head"
 
 LATEST=$(curl -s "$HTTP_URL/$PREFIX/latest.txt")
 echo "Latest snapshot block: $LATEST"
@@ -46,7 +46,7 @@ main() {
   mkdir -p "$DATA_PATH"
   echo "Snapshot block: $BLOCK"
 
-  [ -d "$DATA_PATH" ] && [ -n "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ] && HTTP_NO_HEAD_FLAG="--http-no-head"
+  [ -d "$DATA_PATH" ] && [ -n "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ] && HTTP_NO_HEAD_FLAG=""
 
   FILES_PATH="/tmp/files.txt"
   curl -s "$HTTP_URL/$PREFIX/$BLOCK/$DATA_TYPE/files.txt" -o $FILES_PATH

--- a/down_rclone_archival.sh
+++ b/down_rclone_archival.sh
@@ -13,6 +13,9 @@ set -e
 # - Set $BWLIMIT to the maximum bandwidth to use for download in case you want to limit it. (default: 10G)
 # - Set $DATA_PATH to the path where you want to download the snapshot (default: /mnt/nvme/data/$DATA_TYPE)
 # - Set $BLOCK to the block height of the snapshot you want to download. If not set, it will download the latest snapshot.
+# - Set $RETRIES to the number of retries for each file. (default: 20)
+# - Set $CHECKERS to the number of checkers to use. (default: $THREADS)
+# - Set $LOW_LEVEL_RETRIES to the number of low level retries. (default: 10)
 
 if ! type rclone >/dev/null 2>&1
 then
@@ -43,9 +46,7 @@ main() {
   mkdir -p "$DATA_PATH"
   echo "Snapshot block: $BLOCK"
 
-  if [ -z "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ]; then
-      HTTP_NO_HEAD_FLAG="--http-no-head"
-  fi
+  [ -d "$DATA_PATH" ] && [ -n "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ] && HTTP_NO_HEAD_FLAG="--http-no-head"
 
   FILES_PATH="/tmp/files.txt"
   curl -s "$HTTP_URL/$PREFIX/$BLOCK/$DATA_TYPE/files.txt" -o $FILES_PATH

--- a/down_rclone_archival.sh
+++ b/down_rclone_archival.sh
@@ -13,9 +13,10 @@ set -e
 # - Set $BWLIMIT to the maximum bandwidth to use for download in case you want to limit it. (default: 10G)
 # - Set $DATA_PATH to the path where you want to download the snapshot (default: /mnt/nvme/data/$DATA_TYPE)
 # - Set $BLOCK to the block height of the snapshot you want to download. If not set, it will download the latest snapshot.
-# - Set $RETRIES to the number of retries for each file. (default: 20)
+# - Set $RETRIES to the number of retries for each file. (default: 200)
 # - Set $CHECKERS to the number of checkers to use. (default: $THREADS)
 # - Set $LOW_LEVEL_RETRIES to the number of low level retries. (default: 10)
+# - Set $ENABLE_HTTP_NO_HEAD to true if you want to add --http-no-head flag on rclone (default: false)
 
 if ! type rclone >/dev/null 2>&1
 then
@@ -30,12 +31,16 @@ HTTP_URL="https://snapshot.neardata.xyz"
 : "${DATA_TYPE:=cold-data}"
 : "${DATA_PATH:=/mnt/nvme/data/$DATA_TYPE}"
 : "${BWLIMIT:=10G}"
-: "${RETRIES:=20}"
+: "${RETRIES:=200}"
 : "${CHECKERS:=128}"
 : "${LOW_LEVEL_RETRIES:=10}"
+: "${ENABLE_HTTP_NO_HEAD:=false}"
 
 PREFIX="$CHAIN_ID/archival"
-HTTP_NO_HEAD_FLAG="--http-no-head"
+HTTP_NO_HEAD_FLAG=""
+if [ "$ENABLE_HTTP_NO_HEAD" = true ]; then
+  HTTP_NO_HEAD_FLAG="--http-no-head"
+fi
 
 LATEST=$(curl -s "$HTTP_URL/$PREFIX/latest.txt")
 echo "Latest snapshot block: $LATEST"
@@ -46,7 +51,10 @@ main() {
   mkdir -p "$DATA_PATH"
   echo "Snapshot block: $BLOCK"
 
-  [ -d "$DATA_PATH" ] && [ -n "$(find "$DATA_PATH" -maxdepth 1 -not -name '.' -not -name '..' -print -quit)" ] && HTTP_NO_HEAD_FLAG=""
+  if [ -d "$DATA_PATH" ] && [ -n "$(ls -A "$DATA_PATH")" ]; then
+    echo "Data path exists and is not empty, skipping --http-no-head flag on rclone"
+    HTTP_NO_HEAD_FLAG=""
+  fi
 
   FILES_PATH="/tmp/files.txt"
   curl -s "$HTTP_URL/$PREFIX/$BLOCK/$DATA_TYPE/files.txt" -o $FILES_PATH


### PR DESCRIPTION
Helps with #5 
- Introduces `RETRIES` flag, default to 20, but 200 for archival.
- Introduces `ENABLE_HTTP_NO_HEAD` flag, which defaults to false. If it's enabled, then download will start immediately, but is not guaranteed to finish correctly. So it's not recommended to use.